### PR TITLE
Build ffmpeg and yt-dlp instead of using precompiled binaries

### DIFF
--- a/dont-install-binaries-from-repo.patch
+++ b/dont-install-binaries-from-repo.patch
@@ -1,0 +1,15 @@
+--- a/meson.build
++++ b/meson.build
+@@ -11,10 +11,8 @@
+ subdir('po')
+ 
+ executable('org.nickvision.tubeconverter', sources, dependencies: [threads, adwaita, jsoncpp], install: true)
+-install_data('yt-dlp', install_dir: 'bin', install_mode: 'rwxrwxrwx')
+-install_data('ffmpeg', install_dir: 'bin', install_mode: 'rwxrwxrwx')
+ install_data(resources, install_dir: 'share/icons/hicolor/scalable/apps')
+ install_data(resources_symbolic, install_dir: 'share/icons/hicolor/symbolic/apps')
+ install_data('org.nickvision.tubeconverter.desktop', install_dir: 'share/applications')
+ install_data('org.nickvision.tubeconverter.metainfo.xml', install_dir: 'share/metainfo')
+-gnome.post_install(gtk_update_icon_cache: true, update_desktop_database: true)
+\ No newline at end of file
++gnome.post_install(gtk_update_icon_cache: true, update_desktop_database: true)

--- a/org.nickvision.tubeconverter.json
+++ b/org.nickvision.tubeconverter.json
@@ -13,6 +13,162 @@
         "--filesystem=host"
     ],
     "modules" : [
+    	{
+            "name": "ffmpeg",
+            "config-opts": [
+                "--disable-debug",
+                "--disable-doc",
+                "--disable-static",
+                "--enable-gpl",
+                "--enable-shared",
+                "--disable-ffplay",
+                "--disable-devices",
+                "--enable-gnutls",
+                "--enable-libmp3lame",
+                "--enable-libvorbis"
+            ],
+            "cleanup": [
+                "/share/ffmpeg"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://ffmpeg.org/releases/ffmpeg-5.0.1.tar.xz",
+                    "sha256": "ef2efae259ce80a240de48ec85ecb062cecca26e4352ffb3fda562c21a93007b",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://ffmpeg.org/releases/",
+                        "pattern": ">(ffmpeg-([\\d.]+)\\.tar\\.xz)<"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "pyxattr",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --prefix=/app ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/iustin/pyxattr/archive/refs/tags/v0.7.2.tar.gz",
+                    "sha256": "a1f4b92ffb2193fd381ea352a2a5b60683a4c58c2e7d9468ba7fb71653a3d160",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/iustin/pyxattr/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": "\"https://github.com/iustin/pyxattr/archive/refs/tags/\" + $version + \".tar.gz\""
+                    }
+                }
+            ]
+        },
+        {
+            "name": "mutagen",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --no-build-isolation --prefix=/app ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/quodlibet/mutagen/archive/refs/tags/release-1.46.0.tar.gz",
+                    "sha256": "734455642e734983353a85ec6e00c809564c63e53ec10cffc1152d51dd576b5e",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/quodlibet/mutagen/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": "\"https://github.com/quodlibet/mutagen/archive/refs/tags/\" + $version + \".tar.gz\""
+                    }
+                }
+            ]
+        },
+        {
+            "name": "pycryptodomex",
+            "buildsystem": "simple",
+            "build-commands": [
+                "touch .separate_namespace",
+                "pip3 install --prefix=/app ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/Legrandin/pycryptodome/archive/refs/tags/v3.15.0.tar.gz",
+                    "sha256": "10356f1e0a76d87688482d497a490e10759d1c7e915731d1932c95030bd48241",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/Legrandin/pycryptodome/tags",
+                        "version-query": "[.[].name | select(test(\"^v?[0-9.]+$\"))] | sort_by(sub(\"^v\"; \"\") | split(\".\") | map(tonumber))[-1]",
+                        "url-query": "\"https://github.com/Legrandin/pycryptodome/archive/refs/tags/\" + $version + \".tar.gz\""
+                    }
+                }
+            ]
+        },
+        {
+            "name": "websockets",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --prefix=/app ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/aaugustin/websockets/archive/refs/tags/10.4.tar.gz",
+                    "sha256": "5c7f345bd7924544db691de2f21c80b6fed1f303a54bfa650b782016b64e54ae",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/aaugustin/websockets/tags",
+                        "version-query": "[.[].name | select(test(\"^v?[0-9.]+$\"))] | sort_by(sub(\"^v\"; \"\") | split(\".\") | map(tonumber))[-1]",
+                        "url-query": "\"https://github.com/aaugustin/websockets/archive/refs/tags/\" + $version + \".tar.gz\""
+                    }
+                }
+            ]
+        },
+        {
+            "name": "brotli",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --prefix=/app ."
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/google/brotli/archive/refs/tags/v1.0.9.tar.gz",
+                    "sha256": "f9e8d81d0405ba66d181529af42a3354f838c939095ff99930da6aa9cdf6fe46",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/google/brotli/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": "\"https://github.com/google/brotli/archive/refs/tags/\" + $version + \".tar.gz\""
+                    }
+                }
+            ]
+        },
+    	{
+            "name": "yt-dlp",
+            "no-autogen": true,
+            "no-make-install": true,
+            "make-args": [
+                "yt-dlp",
+                "PYTHON=/usr/bin/python3"
+            ],
+            "post-install": [
+                "install yt-dlp /app/bin"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/yt-dlp/yt-dlp/releases/download/2022.10.04/yt-dlp.tar.gz",
+                    "sha256": "bd3cf6413cd92a400ff015633372a1454906414226f924b57c1f5826b9abc1a8",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/yt-dlp/yt-dlp/tags",
+                        "version-query": "[.[].name] | sort[-1]",
+                        "url-query": "\"https://github.com/yt-dlp/yt-dlp/releases/download/\" + $version + \"/yt-dlp.tar.gz\""
+                    }
+                }
+            ]
+        },
         {
             "name": "jsoncpp",
             "buildsystem": "meson",
@@ -35,6 +191,10 @@
                     "type": "git",
                     "url": "https://github.com/nlogozzo/NickvisionTubeConverter.git",
                     "tag": "2022.10.3"
+                },
+                {
+                    "type": "patch",
+                    "path": "dont-install-binaries-from-repo.patch"
                 }
             ]
         }


### PR DESCRIPTION
I looked at manifests of [MPV](https://github.com/flathub/io.mpv.Mpv) and [VideoDownloader](https://github.com/flathub/com.github.unrud.VideoDownloader) to understand how to add ffmpeg and yt-dlp to the manifest. The versions of ffmpeg and yt-dlp are the same as before. Modules pyxattr, mutagen, pycryptodomex, websockets and brotli are dependencies for yt-dlp. Also added the patch to prevent installing binaries from TubeConverter repo.
I built it and tried to download a few videos from youtube, it works.
Since both MPV and VideoDownloader build and run on ARM, I believe this change should fix nlogozzo/NickvisionTubeConverter#16