### PR TITLE
V2023.2.0

### DIFF
--- a/org.nickvision.tubeconverter.json
+++ b/org.nickvision.tubeconverter.json
@@ -98,8 +98,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Legrandin/pycryptodome/archive/refs/tags/v3.16.0.tar.gz",
-                    "sha256": "c8f6878f11e6164b663058246d2c3ecc3c445f9cbff03dea97cee80c4223b9ff",
+                    "url": "https://github.com/Legrandin/pycryptodome/archive/refs/tags/v3.17.0.tar.gz",
+                    "sha256": "d677199dc3f4d502d6d78bd8855f313eed427be4545bd6a8188c7fc0799ea379",
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://api.github.com/repos/Legrandin/pycryptodome/tags",
@@ -195,7 +195,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/nlogozzo/NickvisionTubeConverter.git",
-                    "tag": "2022.11.1"
+                    "tag": "2023.2.0"
                 }
             ]
         }


### PR DESCRIPTION
https://github.com/nlogozzo/NickvisionTubeConverter/pull/44

Build will fail because the version is not yet tagged.
