### PR TITLE
runtime: Update to GNOME 48

### DIFF
--- a/org.nickvision.tubeconverter.json
+++ b/org.nickvision.tubeconverter.json
@@ -78,16 +78,16 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-02-27-14-16/ffmpeg-n7.1-214-g71889a8437-linux64-gpl-7.1.tar.xz",
-                    "sha256": "7a1ee831780063f4af4ae3b9977a2583df162ecb2523b863338093c08d5d4eff",
+                    "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-02-28-14-15/ffmpeg-n7.1-214-g71889a8437-linux64-gpl-7.1.tar.xz",
+                    "sha256": "12dfc186d97bfd3380bbf4d90d91c94744ee89857b3de353d6253ff3f9e9b90d",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "archive",
-                    "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-02-27-14-16/ffmpeg-n7.1-214-g71889a8437-linuxarm64-gpl-7.1.tar.xz",
-                    "sha256": "d7b80fb8b9d75c24de77255d2ec7502cfc8aef9ca7d537f45bbd6980c136c4ec",
+                    "url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2025-02-28-14-15/ffmpeg-n7.1-214-g71889a8437-linuxarm64-gpl-7.1.tar.xz",
+                    "sha256": "9410e02154bb63ffc0008785638369d106b71cbe02d2b62a66ecf511e21f6bb1",
                     "only-arches": [
                         "aarch64"
                     ]

--- a/org.nickvision.tubeconverter.json
+++ b/org.nickvision.tubeconverter.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.nickvision.tubeconverter",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "command" : "org.nickvision.tubeconverter",
     "finish-args":[


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7

### Please confirm your submission meets all the criteria

- [ ] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [ ] My pull request follows the instructions at [App Submission][submission].
- [ ] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [ ] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [ ] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [ ] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [ ] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission
