### PR TITLE
Update org.nickvision.tubeconverter.json

### DIFF
--- a/org.nickvision.tubeconverter.json
+++ b/org.nickvision.tubeconverter.json
@@ -13,7 +13,16 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.freedesktop.secrets",
-        "--filesystem=xdg-download"
+        "--filesystem=xdg-download",
+        "--filesystem=~/.config/BraveSoftware/Brave-Browser:ro",
+        "--filesystem=~/.config/google-chrome:ro",
+        "--filesystem=~/.config/chromium:ro",
+        "--filesystem=~/.config/microsoft-edge:ro",
+        "--filesystem=~/.mozilla/firefox:ro",
+        "--filesystem=~/snap/firefox/common/.mozilla/firefox:ro",
+        "--filesystem=~/.config/opera:ro",
+        "--filesystem=~/.config/vivaldi:ro",
+        "--filesystem=~/.config/naver-whale:ro"
     ],
     "cleanup":[
         "/include",


### PR DESCRIPTION
`yt-dlp` contains a feature called `Cookies from Browser` that allows users to input a browser they use and it will automatically pull the cookies from that browser for downloading, without requiring the user to manually add a path to an exported txt cookies file.

In the Parabolic UI, we have added a dropdown to allow users to select one of the supported browsers to pass to `yt-dlp`. 

The new paths added to the filesystem permissions are the paths that `yt-dlp` uses in its source code for looking up the cookies from these supported browsers. Thus, we have added them to Parabolic to allow the flatpak app to read said directories and allow yt-dlp in Parabolic to properly find the cookies.