### PR TITLE
V2025.11.0

### DIFF
--- a/org.nickvision.tubeconverter.json
+++ b/org.nickvision.tubeconverter.json
@@ -233,7 +233,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/NickvisionApps/Parabolic.git",
-                    "tag": "2025.10.3"
+                    "tag": "2025.11.0"
                 }
             ]
         }


### PR DESCRIPTION
`yt-dlp` contains a feature called `Cookies from Browser` that allows users to input a browser they use and it will automatically pull the cookies from that browser for downloading, without requiring the user to manually add a path to an exported txt cookies file.

In the Parabolic UI, we have added a dropdown to allow users to select one of the supported browsers to pass to `yt-dlp`. 

The new paths added to the filesystem permissions are the paths that `yt-dlp` uses in its source code for looking up the cookies from these supported browsers. Thus, we have added them to Parabolic to allow the flatpak app to read said directories and allow yt-dlp in Parabolic to properly find the cookies.